### PR TITLE
[Fix #12] Added pagination to watchlist, alarm- and device-list.

### DIFF
--- a/ios/AlarmApp/AlarmApp.xcodeproj/project.pbxproj
+++ b/ios/AlarmApp/AlarmApp.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		30FD5B0F27F1ADD300F61F3F /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FD5B0E27F1ADD300F61F3F /* Credentials.swift */; };
 		30FD5B1127F1C1C500F61F3F /* PushNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30FD5B1027F1C1C500F61F3F /* PushNotificationCenter.swift */; };
 		30FD5B1427F1CABA00F61F3F /* IQKeyboardManagerSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 30FD5B1327F1CABA00F61F3F /* IQKeyboardManagerSwift */; };
+		F113B91E2D14775600420983 /* PaginatedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F113B91C2D14775600420983 /* PaginatedViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -161,6 +162,7 @@
 		30FBB9C927CD417F008302D0 /* DetailsItem.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailsItem.xib; sourceTree = "<group>"; };
 		30FD5B0E27F1ADD300F61F3F /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
 		30FD5B1027F1C1C500F61F3F /* PushNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationCenter.swift; sourceTree = "<group>"; };
+		F113B91C2D14775600420983 /* PaginatedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedViewModel.swift; sourceTree = "<group>"; };
 		F1C9181E294300F70020DFCE /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		F1C918202943010A0020DFCE /* .swift-format */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ".swift-format"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -216,6 +218,7 @@
 				30E1D0F427E8ECF600FCB4DA /* Fragments */,
 				30E1D0CE27E3E29C00FCB4DA /* PushGateway */,
 				30FBB9C427CD4115008302D0 /* Views */,
+				F113B91D2D14775600420983 /* Pagination */,
 				3056B76927CE603300ED443B /* Network */,
 				3056B77A27CE896F00ED443B /* Material */,
 				309A860B27DF659F00F69ED0 /* MaterialUI */,
@@ -376,6 +379,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		F113B91D2D14775600420983 /* Pagination */ = {
+			isa = PBXGroup;
+			children = (
+				F113B91C2D14775600420983 /* PaginatedViewModel.swift */,
+			);
+			path = Pagination;
+			sourceTree = "<group>";
+		};
 		F1C918242943275B0020DFCE /* External */ = {
 			isa = PBXGroup;
 			children = (
@@ -534,6 +545,7 @@
 				3008B04F296C245500A05731 /* MaterialTextfield.swift in Sources */,
 				30F6C36627D6B8AD00884CE8 /* SeparatorItem.swift in Sources */,
 				3008B04B296C17FA00A05731 /* MaterialButton.swift in Sources */,
+				F113B91E2D14775600420983 /* PaginatedViewModel.swift in Sources */,
 				3056B77C27CE899000ED443B /* MaterialLabel.swift in Sources */,
 				3056B77627CE696B00ED443B /* AlarmListItem.swift in Sources */,
 				3044433D294B81D500FE40D1 /* DecoratedLabel.swift in Sources */,

--- a/ios/AlarmApp/AlarmApp.xcodeproj/project.pbxproj
+++ b/ios/AlarmApp/AlarmApp.xcodeproj/project.pbxproj
@@ -789,7 +789,7 @@
 		};
 		30FBB9A227CCEEEC008302D0 /* XCRemoteSwiftPackageReference "cumulocity-clients-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SoftwareAG/cumulocity-clients-swift";
+			repositoryURL = "https://github.com/Cumulocity-IoT/cumulocity-clients-swift";
 			requirement = {
 				branch = main;
 				kind = branch;

--- a/ios/AlarmApp/AlarmApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/AlarmApp/AlarmApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,10 +1,10 @@
 {
-  "originHash" : "114fe3659303e1366d25d790640766abfdf6b0fadec03cbd3866ebdb05f5a710",
+  "originHash" : "894cebe1937caf51d64a44da982a158d9b8254b0fed0cc3b475be2e020af0837",
   "pins" : [
     {
       "identity" : "cumulocity-clients-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SoftwareAG/cumulocity-clients-swift",
+      "location" : "https://github.com/cumulocity-iot/cumulocity-clients-swift",
       "state" : {
         "branch" : "main",
         "revision" : "fd6203c62a8f7ca6b04fdde22f8c472359e1c3ae"

--- a/ios/AlarmApp/AlarmApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/AlarmApp/AlarmApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,9 +1,10 @@
 {
+  "originHash" : "114fe3659303e1366d25d790640766abfdf6b0fadec03cbd3866ebdb05f5a710",
   "pins" : [
     {
       "identity" : "cumulocity-clients-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Cumulocity-IoT/cumulocity-clients-swift",
+      "location" : "https://github.com/SoftwareAG/cumulocity-clients-swift",
       "state" : {
         "branch" : "main",
         "revision" : "fd6203c62a8f7ca6b04fdde22f8c472359e1c3ae"
@@ -37,5 +38,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ios/AlarmApp/AlarmApp/Controller/AlarmFilterViewController.swift
+++ b/ios/AlarmApp/AlarmApp/Controller/AlarmFilterViewController.swift
@@ -35,7 +35,7 @@ class AlarmFilterViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        delegate?.fetchAlarms()
+        delegate?.reload()
     }
 
     override func viewDidLoad() {

--- a/ios/AlarmApp/AlarmApp/Controller/DashboardViewController.swift
+++ b/ios/AlarmApp/AlarmApp/Controller/DashboardViewController.swift
@@ -71,7 +71,7 @@ class DashboardViewController: UIViewController, AlarmListReloadDelegate, EmptyA
         let textfields = [self.criticalCountItem, self.majorCountItem, self.minorCountItem, self.warningCountItem]
         arguments.enumerated().publisher
             .flatMap { index, arg in
-                return alarmsApi.getAlarms(
+                alarmsApi.getAlarms(
                     pageSize: 1,
                     severity: [arg.rawValue],
                     status: [C8yAlarm.C8yStatus.active.rawValue],

--- a/ios/AlarmApp/AlarmApp/Controller/DashboardViewController.swift
+++ b/ios/AlarmApp/AlarmApp/Controller/DashboardViewController.swift
@@ -64,58 +64,29 @@ class DashboardViewController: UIViewController, AlarmListReloadDelegate, EmptyA
 
     private func fetchAlarmCount() {
         let alarmsApi = Cumulocity.Core.shared.alarms.alarmsApi
-        alarmsApi.getNumberOfAlarms(
-            severity: [C8yAlarm.C8ySeverity.critical.rawValue],
-            status: [C8yAlarm.C8yStatus.active.rawValue]
-        )
-        .receive(on: DispatchQueue.main)
-        .sink(
-            receiveCompletion: { _ in
-            },
-            receiveValue: { value in
-                self.criticalCountItem.countLabel.text = String(value)
+        let arguments = [
+            C8yAlarm.C8ySeverity.critical, C8yAlarm.C8ySeverity.major, C8yAlarm.C8ySeverity.minor,
+            C8yAlarm.C8ySeverity.warning,
+        ]
+        let textfields = [self.criticalCountItem, self.majorCountItem, self.minorCountItem, self.warningCountItem]
+        arguments.enumerated().publisher
+            .flatMap { index, arg in
+                return alarmsApi.getAlarms(
+                    pageSize: 1,
+                    severity: [arg.rawValue],
+                    status: [C8yAlarm.C8yStatus.active.rawValue],
+                    withTotalElements: true
+                )
+                .map { $0.statistics?.totalElements ?? 0 }
+                .receive(on: DispatchQueue.main)
+                .catch { _ in Just(0) }
+                .map { (index, $0) }
+                .eraseToAnyPublisher()
             }
-        )
-        .store(in: &self.cancellableSet)
-        alarmsApi.getNumberOfAlarms(
-            severity: [C8yAlarm.C8ySeverity.major.rawValue],
-            status: [C8yAlarm.C8yStatus.active.rawValue]
-        )
-        .receive(on: DispatchQueue.main)
-        .sink(
-            receiveCompletion: { _ in
-            },
-            receiveValue: { value in
-                self.majorCountItem.countLabel.text = String(value)
+            .sink { index, result in
+                textfields[index]?.countLabel.text = String(result ?? 0)
             }
-        )
-        .store(in: &self.cancellableSet)
-        alarmsApi.getNumberOfAlarms(
-            severity: [C8yAlarm.C8ySeverity.minor.rawValue],
-            status: [C8yAlarm.C8yStatus.active.rawValue]
-        )
-        .receive(on: DispatchQueue.main)
-        .sink(
-            receiveCompletion: { _ in
-            },
-            receiveValue: { value in
-                self.minorCountItem.countLabel.text = String(value)
-            }
-        )
-        .store(in: &self.cancellableSet)
-        alarmsApi.getNumberOfAlarms(
-            severity: [C8yAlarm.C8ySeverity.warning.rawValue],
-            status: [C8yAlarm.C8yStatus.active.rawValue]
-        )
-        .receive(on: DispatchQueue.main)
-        .sink(
-            receiveCompletion: { _ in
-            },
-            receiveValue: { value in
-                self.warningCountItem.countLabel.text = String(value)
-            }
-        )
-        .store(in: &self.cancellableSet)
+            .store(in: &self.cancellableSet)
     }
 
     ///  update tag list for receiving push notifications

--- a/ios/AlarmApp/AlarmApp/Controller/DashboardViewController.swift
+++ b/ios/AlarmApp/AlarmApp/Controller/DashboardViewController.swift
@@ -90,7 +90,7 @@ class DashboardViewController: UIViewController, AlarmListReloadDelegate, EmptyA
     }
 
     ///  update tag list for receiving push notifications
-    func fetchAlarms() {
+    func reload() {
         SubscribedAlarmFilter.shared.resolvedDeviceId = nil
         if let deviceName = SubscribedAlarmFilter.shared.deviceName {
             let managedObjectsApi = Cumulocity.Core.shared.inventory.managedObjectsApi

--- a/ios/AlarmApp/AlarmApp/Extensions/AlarmsApi.swift
+++ b/ios/AlarmApp/AlarmApp/Extensions/AlarmsApi.swift
@@ -19,7 +19,9 @@ import Combine
 import CumulocityCoreLibrary
 
 extension AlarmsApi {
-    public func getAlarmsByFilter(filter: AlarmFilter, source: String?) -> AnyPublisher<C8yAlarmCollection, Error> {
+    public func getAlarmsByFilter(filter: AlarmFilter, page: Int? = 1, source: String?) -> AnyPublisher<
+        C8yAlarmCollection, Error
+    > {
         var severities: [String] = []
         for s in filter.severity {
             severities.append(s.rawValue)
@@ -34,6 +36,15 @@ extension AlarmsApi {
                 types.append(singleAlarmType)
             }
         }
-        return self.getAlarms(pageSize: 50, severity: severities, source: source, status: statuses, type: types)
+        return self.getAlarms(
+            currentPage: page,
+            pageSize: 10,
+            severity: severities,
+            source: source,
+            status: statuses,
+            type: types,
+            withTotalElements: true,
+            withTotalPages: true
+        )
     }
 }

--- a/ios/AlarmApp/AlarmApp/Extensions/AlarmsApi.swift
+++ b/ios/AlarmApp/AlarmApp/Extensions/AlarmsApi.swift
@@ -38,7 +38,7 @@ extension AlarmsApi {
         }
         return self.getAlarms(
             currentPage: page,
-            pageSize: 10,
+            pageSize: 50,
             severity: severities,
             source: source,
             status: statuses,

--- a/ios/AlarmApp/AlarmApp/Extensions/C8yAlarm.swift
+++ b/ios/AlarmApp/AlarmApp/Extensions/C8yAlarm.swift
@@ -25,8 +25,10 @@ extension C8yAlarm.C8yStatus {
         switch self {
         case .acknowledged:
             return %"alarm_status_acknowledged"
+
         case .cleared:
             return %"alarm_status_cleared"
+
         default:
             return %"alarm_status_active"
         }
@@ -36,8 +38,10 @@ extension C8yAlarm.C8yStatus {
         switch self {
         case .acknowledged:
             return %"alarm_status_acknowledged_verb"
+
         case .cleared:
             return %"alarm_status_cleared_verb"
+
         default:
             return %"alarm_status_active_verb"
         }

--- a/ios/AlarmApp/AlarmApp/Extensions/UITableViewController.swift
+++ b/ios/AlarmApp/AlarmApp/Extensions/UITableViewController.swift
@@ -20,7 +20,7 @@ extension UITableViewController {
     static func prepareForAlarms(
         with tableView: UITableView,
         delegate: EmptyAlarmsDelegate?
-    ){
+    ) {
         AlarmListItem.register(for: tableView)
         ListViewHeaderItem.register(for: tableView)
         tableView.tableFooterView = UIView()

--- a/ios/AlarmApp/AlarmApp/Pagination/PaginatedViewModel.swift
+++ b/ios/AlarmApp/AlarmApp/Pagination/PaginatedViewModel.swift
@@ -1,0 +1,98 @@
+//  Copyright (c) 2023 Software AG, Darmstadt, Germany and/or its licensors
+//
+//  SPDX-License-Identifier: Apache-2.0
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import CumulocityCoreLibrary
+import Foundation
+
+struct Page {
+    var elements: [C8yAlarm]  // Use a generic type if needed
+}
+
+final class PaginatedViewModel {
+    private(set) var pages: [Int: Page] = [:]
+    var pageStatistics: C8yPageStatistics? = C8yPageStatistics()
+
+    init() {
+    }
+
+    var totalCount: Int {
+        pageStatistics?.totalElements ?? 0
+    }
+
+    var currentCount: Int {
+        pages.values.flatMap { $0.elements }.count
+    }
+
+    func appendAlarms(toPage pageIndex: Int, newAlarms: [C8yAlarm]) {
+        if pages[pageIndex] == nil {
+            pages[pageIndex] = Page(elements: [])
+        }
+        pages[pageIndex]?.elements = newAlarms
+    }
+
+    func replaceAlarm(alarm: C8yAlarm, at index: Int) -> Bool {
+        var accumulatedIndex = 0
+        for (pageNumber, page) in pages {
+            let pageSize = page.elements.count
+            if index < accumulatedIndex + pageSize {
+                let localIndex = index - accumulatedIndex
+                print(localIndex)
+                pages[pageNumber]?.elements[localIndex] = alarm
+                return true
+            }
+            accumulatedIndex += pageSize
+        }
+        return false
+    }
+
+    func alarm(at index: Int) -> C8yAlarm? {
+        guard index >= 0 && index < currentCount else {
+            return nil
+        }
+        // Flatten pages while preserving page order
+        let allElements = pages.keys.sorted()
+            .compactMap { pages[$0]?.elements }
+            .flatMap { $0 }
+        return allElements[index]
+    }
+
+    func nextPage() -> Int {
+        if let currentPage = pageStatistics?.currentPage {
+            return currentPage + 1
+        } else {
+            return 1
+        }
+    }
+
+    func shouldLoadMorePages() -> Bool {
+        if let currentPage = pageStatistics?.currentPage, let totalPages = pageStatistics?.totalPages {
+            return currentPage <= totalPages
+        } else {
+            return true
+        }
+    }
+
+    func calculateIndexPathsToReload(from newAlarms: [C8yAlarm]) -> [IndexPath] {
+        let startIndex = currentCount - newAlarms.count
+        let endIndex = startIndex + newAlarms.count
+        return (startIndex..<endIndex).map { IndexPath(row: $0, section: 0) }
+    }
+
+    /// cell at that index path is beyond the visible alarm count
+    func isLoadingCell(for indexPath: IndexPath) -> Bool {
+        indexPath.row >= currentCount
+    }
+}


### PR DESCRIPTION
- Implementation is based on `tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath])`
- This message will cause a reload of the list by requesting current page + 1
- Afterwards affected index paths are calculated and the table view refreshed
- Alarms are stored as `pages: [Int: Page]` to preserve order

What's missing: 

- update indication on the list item itself, it shows empty strings for now, prob. a loading indicator is wanted?
- support pagination within `AlarmListViewController`